### PR TITLE
Show protocol type in Windows node selector

### DIFF
--- a/src/__tests__/node-protocol.test.ts
+++ b/src/__tests__/node-protocol.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildNodeProtocolMap, formatNodeProtocol } from '../components/home/node-protocol';
+
+describe('node protocol helpers', () => {
+    it('normalizes server proxy protocol types for display', () => {
+        expect(formatNodeProtocol('VLESS')).toBe('vless');
+        expect(formatNodeProtocol(' AnyTLS ')).toBe('anytls');
+    });
+
+    it('hides selector-like entries because they are not node protocols', () => {
+        expect(formatNodeProtocol('Selector')).toBeUndefined();
+        expect(formatNodeProtocol('URLTest')).toBeUndefined();
+        expect(formatNodeProtocol('Direct')).toBeUndefined();
+    });
+
+    it('builds a protocol map for the visible node list', () => {
+        const response = {
+            proxies: {
+                auto: { type: 'URLTest' },
+                node1: { type: 'VLESS' },
+                node2: { type: 'AnyTLS' },
+                hidden: { type: 'TUIC' },
+            },
+        };
+
+        expect(buildNodeProtocolMap(['auto', 'node1', 'node2'], response)).toEqual({
+            node1: 'vless',
+            node2: 'anytls',
+        });
+    });
+
+    it('tolerates malformed proxy responses', () => {
+        expect(buildNodeProtocolMap(['node1'], null)).toEqual({});
+        expect(buildNodeProtocolMap(['node1'], { proxies: { node1: {} } })).toEqual({});
+    });
+});

--- a/src/components/home/node-option.tsx
+++ b/src/components/home/node-option.tsx
@@ -23,15 +23,15 @@ interface ProxyResponse {
 
 interface NodeOptionProps {
     nodeName: string;
+    protocol?: string;
     showDelay: boolean;
 }
 
 // 样式常量
 const STYLES = {
-    container: 'flex justify-between items-center w-full',
-    nodeName: 'truncate font-medium flex-1 min-w-0 text-sm',
-    delayContainer: 'ml-2 text-sm font-medium transition-all duration-300 ease flex items-center gap-1.5',
-    delayDot: 'inline-block w-2 h-2 rounded-full transition-all duration-300 ease',
+    container: 'grid grid-cols-[minmax(0,1fr)_auto_minmax(3.5rem,auto)] items-center gap-2 w-full',
+    nodeName: 'truncate font-medium min-w-0 text-sm',
+    protocol: 'rounded-md px-1.5 py-0.5 text-[10px] font-semibold leading-4',
     startingContainer: 'onebox-select'
 } as const;
 
@@ -95,9 +95,9 @@ const DelayIndicator = ({ delay, showDelay, delayText }: DelayIndicatorProps) =>
     const displayText = delay === '-' ? delayText : `${delay}ms`;
 
     return (
-        <div className="h-5 flex items-center justify-end">
+        <div className="h-5 flex items-center justify-end min-w-[3.5rem]">
             {showDelay ? (
-                <div className="ml-2 text-sm font-medium transition-all duration-300 ease">
+                <div className="text-sm font-medium transition-all duration-300 ease">
                     {displayText}
                 </div>
             ) : (
@@ -111,7 +111,7 @@ const DelayIndicator = ({ delay, showDelay, delayText }: DelayIndicatorProps) =>
     );
 };
 
-export default function NodeOption({ nodeName, showDelay }: NodeOptionProps) {
+export default function NodeOption({ nodeName, protocol, showDelay }: NodeOptionProps) {
     const [delayText, setDelayText] = useState<string>('-');
     const { delay } = useProxyDelay(nodeName);
 
@@ -153,6 +153,17 @@ export default function NodeOption({ nodeName, showDelay }: NodeOptionProps) {
         <div className={STYLES.container}>
             <span className={STYLES.nodeName} title={displayName}>
                 {displayName}
+            </span>
+            <span
+                className={STYLES.protocol}
+                style={{
+                    visibility: protocol ? "visible" : "hidden",
+                    color: 'var(--onebox-blue)',
+                    background: 'rgba(0, 122, 255, 0.10)',
+                }}
+                title={protocol}
+            >
+                {protocol ?? "proxy"}
             </span>
             <DelayIndicator
                 delay={delay}

--- a/src/components/home/node-protocol.ts
+++ b/src/components/home/node-protocol.ts
@@ -1,0 +1,51 @@
+export type NodeProtocolMap = Record<string, string>;
+
+type ProxyEntry = {
+    type?: unknown;
+};
+
+type ProxiesResponse = {
+    proxies?: Record<string, ProxyEntry | undefined>;
+};
+
+const NON_SERVER_PROXY_TYPES = new Set([
+    "selector",
+    "urltest",
+    "fallback",
+    "loadbalance",
+    "relay",
+    "direct",
+    "reject",
+    "block",
+]);
+
+export function formatNodeProtocol(type: unknown): string | undefined {
+    if (typeof type !== "string") return undefined;
+
+    const normalized = type.trim().toLowerCase();
+    if (!normalized || NON_SERVER_PROXY_TYPES.has(normalized)) {
+        return undefined;
+    }
+
+    return normalized;
+}
+
+export function buildNodeProtocolMap(
+    nodeList: readonly string[],
+    response: unknown,
+): NodeProtocolMap {
+    const proxies =
+        typeof response === "object" && response !== null
+            ? (response as ProxiesResponse).proxies
+            : undefined;
+
+    if (!proxies || typeof proxies !== "object") return {};
+
+    return nodeList.reduce<NodeProtocolMap>((acc, nodeName) => {
+        const protocol = formatNodeProtocol(proxies[nodeName]?.type);
+        if (protocol) {
+            acc[nodeName] = protocol;
+        }
+        return acc;
+    }, {});
+}

--- a/src/components/home/select-node.tsx
+++ b/src/components/home/select-node.tsx
@@ -10,10 +10,23 @@ import {
     AppleSelectOption,
     AppleSelectPlaceholder,
 } from "./apple-select-menu";
+import { buildNodeProtocolMap, type NodeProtocolMap } from "./node-protocol";
 import NodeOption from "./node-option";
 
 const baseUrl = "http://127.0.0.1:9191";
 const proxiesUrl = `${baseUrl}/proxies/ExitGateway`;
+const allProxiesUrl = `${baseUrl}/proxies`;
+
+type SelectorResponse = {
+    all?: string[];
+    now?: string;
+};
+
+type NodeSelectorData = {
+    all: string[];
+    now: string;
+    nodeProtocols: NodeProtocolMap;
+};
 
 type SelectNodeProps = {
     isRunning: boolean;
@@ -25,21 +38,42 @@ export default function SelectNode(props: SelectNodeProps) {
         `swr-${baseUrl}/proxies/ExitGateway-${props.isRunning}`,
         async () => {
             if (!isRunning) {
-                return { all: [], now: "" };
+                return { all: [], now: "", nodeProtocols: {} };
             }
-            const url = `${baseUrl}/proxies/ExitGateway`;
-            const response = await fetch(url, {
-                method: "GET",
-                // @ts-ignore
-                timeout: 3,
-                headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${await getClashApiSecret()}`,
-                },
-            });
-            const res = await response.json();
-            return res;
+            const headers = {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${await getClashApiSecret()}`,
+            };
+            const [selectorResponse, allProxiesResponse] = await Promise.all([
+                fetch(proxiesUrl, {
+                    method: "GET",
+                    // @ts-ignore
+                    timeout: 3,
+                    headers,
+                }),
+                fetch(allProxiesUrl, {
+                    method: "GET",
+                    // @ts-ignore
+                    timeout: 3,
+                    headers,
+                })
+                    .then((response) => response.json())
+                    .catch((error) => {
+                        console.warn("Failed to fetch proxy protocol metadata:", error);
+                        return undefined;
+                    }),
+            ]);
+            const selector = (await selectorResponse.json()) as SelectorResponse;
+            const nodeList = Array.isArray(selector.all) ? selector.all : [];
+            return {
+                all: nodeList,
+                now: selector.now ?? "",
+                nodeProtocols: buildNodeProtocolMap(
+                    nodeList,
+                    allProxiesResponse,
+                ),
+            } satisfies NodeSelectorData;
         },
         {
             revalidateOnFocus: true,
@@ -75,6 +109,7 @@ export default function SelectNode(props: SelectNodeProps) {
             isRunning={isRunning}
             nodeList={data.all}
             currentNode={data.now}
+            nodeProtocols={data.nodeProtocols}
             onUpdate={() => mutate()}
         />
     );
@@ -83,12 +118,13 @@ export default function SelectNode(props: SelectNodeProps) {
 type NodeMenuProps = {
     currentNode: string;
     nodeList: string[];
+    nodeProtocols: NodeProtocolMap;
     isRunning: boolean;
     onUpdate: () => void;
 };
 
 function NodeMenu(props: NodeMenuProps) {
-    const { currentNode, nodeList, onUpdate, isRunning } = props;
+    const { currentNode, nodeList, nodeProtocols, onUpdate, isRunning } = props;
     const [showDelay, setShowDelay] = useState(false);
     const [lastRunning, setLastRunning] = useState(false);
 
@@ -115,8 +151,13 @@ function NodeMenu(props: NodeMenuProps) {
     }, [isRunning, lastRunning]);
 
     const options = useMemo<AppleSelectOption<string>[]>(
-        () => nodeList.map((name) => ({ value: name, key: name })),
-        [nodeList],
+        () =>
+            nodeList.map((name) => ({
+                value: name,
+                key: name,
+                raw: nodeProtocols[name],
+            })),
+        [nodeList, nodeProtocols],
     );
 
     const handleNodeChange = async (node: string) => {
@@ -149,7 +190,11 @@ function NodeMenu(props: NodeMenuProps) {
             onChange={handleNodeChange}
             menuMaxHeight={220}
             renderTrigger={() => (
-                <NodeOption nodeName={currentNode} showDelay={showDelay} />
+                <NodeOption
+                    nodeName={currentNode}
+                    protocol={nodeProtocols[currentNode]}
+                    showDelay={showDelay}
+                />
             )}
             renderOption={({ option, isSelected }) => (
                 <div
@@ -160,6 +205,11 @@ function NodeMenu(props: NodeMenuProps) {
                 >
                     <NodeOption
                         nodeName={option.value}
+                        protocol={
+                            typeof option.raw === "string"
+                                ? option.raw
+                                : undefined
+                        }
                         showDelay={showDelay}
                     />
                 </div>


### PR DESCRIPTION
## Summary
- Fetch proxy metadata from the local Clash-compatible API and map visible node names to their protocol type.
- Display a compact protocol badge (for example `vless`, `anytls`, `tuic`) between the node name and delay in the Windows node selector.
- Keep selector-like entries such as `auto`/`urltest` hidden and tolerate metadata fetch failures by falling back to the existing node list display.

## Test plan
- `npm exec -- vitest run`
- `deno run -A npm:typescript@~5.9.3/bin/tsc`
- `deno task check:tailwind`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true deno task build`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true deno task tauri build --no-bundle`

Note: a full `deno task tauri build` produced the Windows exe/MSI/NSIS bundles locally, then failed only at updater artifact signing because `TAURI_SIGNING_PRIVATE_KEY` is not available in this environment.